### PR TITLE
Remove the version from the description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Oracle NoSQL Database IntelliJ Plugin
 
-Oracle NoSQL Database IntelliJ Plugin Version 1.5.3
-
 ## Overview
 
 The Oracle NoSQL Database IntelliJ Plugin accelerates application development by integrating with IntelliJ IDEA. The plugin enables you to:


### PR DESCRIPTION
I would suggest to remove the version on top of the README as I would imagine this would change overtime. The version can be seen in the releases and further down in the docs. But up to the maintainers.